### PR TITLE
Build dei documenti in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,23 @@
+on: push
+
+jobs:
+  build_documenti:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@v3
+      
+      - name: Builda
+        run: |
+          docker run -i --rm -v "$(pwd)/:/work" -w /work ghcr.io/xu-cheng/texlive-full bash -c '
+            shopt -s globstar
+            set -e
+            for d_path in ./**/d_*.tex; do (
+              cd "$(dirname $d_path)"
+              latexmk -lualatex $(basename $d_path)
+            ) done'
+
+      - name: Upload PDF file
+        uses: actions/upload-artifact@v3
+        with:
+          path: "**/*.pdf”


### PR DESCRIPTION
@alessandro-massarenti rinomina i file da buildare con latexmk in modo che inizino con `d_` (ad es. `assegnazione_appalti/preventivo_costi/preventivo-costi.tex` diventerà `assegnazione_appalti/preventivo_costi/d_preventivo-costi.tex`. 
Trovi i pdf buildati come artifact della run in CI.
Se volessi estendere la pipeline per caricare automaticamente uno zip come release al push di un tag devi creare un nuovo job nello stesso workflow che dipende da `build_documenti`, preleva l'artifact e lo carica come artefatto di release (v. [qui per esempio](https://github.com/sevenelevendevunipd/docs/blob/4dd85916c7887eb2269dbcc19492590d1eb48a70/.github/workflows/pages.yml#L72))