### PR TITLE
Aggiunti i link dei submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,10 @@ _Questa documentazione è rivolta al Committente ed al Cliente._
 > [GitHub Page](https://sweasabi.github.io/documentazione/) con i documenti in formato PDF aggiornati all'ultima versione.
 
 > Pagina delle [Release](https://github.com/SWEasabi/documentazione/releases) completa dei pacchetti per ogni versione rilasciata.
+
+> I contenuti inclusi in questo documento sono:
+> - [Analisi dei Requisiti](https://github.com/SWEasabi/analisi-dei-requisiti)
+> - [Glossario](https://github.com/SWEasabi/glossario)
+> - [Specifica Architetturale](https://github.com/SWEasabi/specifica-architetturale)
+> - [Specifica delle Basi di Dati](https://github.com/SWEasabi/specifica-delle-basi-dati)
+> - [Verbali](https://github.com/SWEasabi/verbali)


### PR DESCRIPTION
Sono stati aggiunti al README.md del repository i link ai repository dei submodules della documentazione. I link aggiunti riportano ai repository di Analisi dei Requisti, Glossario, Specifica Architetturale, Specifica delle Basi di Dati e Verbali